### PR TITLE
Audio player plugin change

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,6 +25,13 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('key.properties')
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
+
 android {
     compileSdkVersion 28
 
@@ -39,7 +46,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.andrewtechful.radio_player"
-        minSdkVersion 16
+        minSdkVersion 22
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
@@ -47,11 +54,21 @@ android {
         multiDexEnabled true
     }
 
+    signingConfigs {
+        release {
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+            storePassword keystoreProperties['storePassword']
+        }
+    }
+
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            // signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,6 +44,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -52,6 +53,11 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+
+    // Temporary fix until alpha10
+    packagingOptions {
+        exclude 'META-INF/proguard/androidx-annotations.pro'
     }
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
          FlutterApplication and put your custom class here. -->
     <application
         android:name="io.flutter.app.FlutterApplication"
-        android:label="radio_player"
+        android:label="Egypt Radio"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true">
         <activity
@@ -31,4 +31,6 @@
             </intent-filter>
         </activity>
     </application>
+
+    <uses-permission android:name="android.permission.INTERNET"></uses-permission>
 </manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.0'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 
 android.enableR8=true
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -15,51 +15,67 @@ def parse_KV_file(file, separator='=')
   if !File.exists? file_abs_path
     return [];
   end
-  pods_ary = []
+  generated_key_values = {}
   skip_line_start_symbols = ["#", "/"]
-  File.foreach(file_abs_path) { |line|
-      next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
-      plugin = line.split(pattern=separator)
-      if plugin.length == 2
-        podname = plugin[0].strip()
-        path = plugin[1].strip()
-        podpath = File.expand_path("#{path}", file_abs_path)
-        pods_ary.push({:name => podname, :path => podpath});
-      else
-        puts "Invalid plugin specification: #{line}"
-      end
-  }
-  return pods_ary
+  File.foreach(file_abs_path) do |line|
+    next if skip_line_start_symbols.any? { |symbol| line =~ /^\s*#{symbol}/ }
+    plugin = line.split(pattern=separator)
+    if plugin.length == 2
+      podname = plugin[0].strip()
+      path = plugin[1].strip()
+      podpath = File.expand_path("#{path}", file_abs_path)
+      generated_key_values[podname] = podpath
+    else
+      puts "Invalid plugin specification: #{line}"
+    end
+  end
+  generated_key_values
 end
 
 target 'Runner' do
   use_frameworks!
+  use_modular_headers!
+  
+  # Flutter Pod
+
+  copied_flutter_dir = File.join(__dir__, 'Flutter')
+  copied_framework_path = File.join(copied_flutter_dir, 'Flutter.framework')
+  copied_podspec_path = File.join(copied_flutter_dir, 'Flutter.podspec')
+  unless File.exist?(copied_framework_path) && File.exist?(copied_podspec_path)
+    # Copy Flutter.framework and Flutter.podspec to Flutter/ to have something to link against if the xcode backend script has not run yet.
+    # That script will copy the correct debug/profile/release version of the framework based on the currently selected Xcode configuration.
+    # CocoaPods will not embed the framework on pod install (before any build phases can generate) if the dylib does not exist.
+
+    generated_xcode_build_settings_path = File.join(copied_flutter_dir, 'Generated.xcconfig')
+    unless File.exist?(generated_xcode_build_settings_path)
+      raise "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+    end
+    generated_xcode_build_settings = parse_KV_file(generated_xcode_build_settings_path)
+    cached_framework_dir = generated_xcode_build_settings['FLUTTER_FRAMEWORK_DIR'];
+
+    unless File.exist?(copied_framework_path)
+      FileUtils.cp_r(File.join(cached_framework_dir, 'Flutter.framework'), copied_flutter_dir)
+    end
+    unless File.exist?(copied_podspec_path)
+      FileUtils.cp(File.join(cached_framework_dir, 'Flutter.podspec'), copied_flutter_dir)
+    end
+  end
+
+  # Keep pod path relative so it can be checked into Podfile.lock.
+  pod 'Flutter', :path => 'Flutter'
+
+  # Plugin Pods
 
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
   # referring to absolute paths on developers' machines.
   system('rm -rf .symlinks')
   system('mkdir -p .symlinks/plugins')
-
-  # Flutter Pods
-  generated_xcode_build_settings = parse_KV_file('./Flutter/Generated.xcconfig')
-  if generated_xcode_build_settings.empty?
-    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter pub get is executed first."
-  end
-  generated_xcode_build_settings.map { |p|
-    if p[:name] == 'FLUTTER_FRAMEWORK_DIR'
-      symlink = File.join('.symlinks', 'flutter')
-      File.symlink(File.dirname(p[:path]), symlink)
-      pod 'Flutter', :path => File.join(symlink, File.basename(p[:path]))
-    end
-  }
-
-  # Plugin Pods
   plugin_pods = parse_KV_file('../.flutter-plugins')
-  plugin_pods.map { |p|
-    symlink = File.join('.symlinks', 'plugins', p[:name])
-    File.symlink(p[:path], symlink)
-    pod p[:name], :path => File.join(symlink, 'ios')
-  }
+  plugin_pods.each do |name, path|
+    symlink = File.join('.symlinks', 'plugins', name)
+    File.symlink(path, symlink)
+    pod name, :path => File.join(symlink, 'ios')
+  end
 end
 
 # Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,33 +2,27 @@ PODS:
   - audioplayers (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - flutter_radio (0.0.1):
-    - Flutter
   - path_provider (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - audioplayers (from `.symlinks/plugins/audioplayers/ios`)
-  - Flutter (from `.symlinks/flutter/ios`)
-  - flutter_radio (from `.symlinks/plugins/flutter_radio/ios`)
+  - Flutter (from `Flutter`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
 
 EXTERNAL SOURCES:
   audioplayers:
     :path: ".symlinks/plugins/audioplayers/ios"
   Flutter:
-    :path: ".symlinks/flutter/ios"
-  flutter_radio:
-    :path: ".symlinks/plugins/flutter_radio/ios"
+    :path: Flutter
   path_provider:
     :path: ".symlinks/plugins/path_provider/ios"
 
 SPEC CHECKSUMS:
   audioplayers: 84f968cea3f2deab00ec4f8ff53358b3c0b3992c
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
-  flutter_radio: 852f82f0ecb1ea21ce24bc3724e95196c6c7c936
   path_provider: fb74bd0465e96b594bb3b5088ee4a4e7bb1f2a9d
 
-PODFILE CHECKSUM: b6a0a141693093b304368d08511b46cf3d1d0ac5
+PODFILE CHECKSUM: 1b66dae606f75376c5f2135a8290850eeb09ae83
 
 COCOAPODS: 1.8.4

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -142,7 +142,6 @@
 				FAA7536DB8D3C2994B60C1EA /* Pods-Runner.release.xcconfig */,
 				8992BA2E34BCDAF35B91B181 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -182,6 +181,7 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = DCUZJ8P3P9;
 						LastSwiftMigration = 0910;
 					};
 				};
@@ -376,6 +376,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = DCUZJ8P3P9;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -509,6 +510,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = DCUZJ8P3P9;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -536,6 +538,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = DCUZJ8P3P9;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
-import 'package:flutter_radio/flutter_radio.dart';
+//import 'package:flutter_radio/flutter_radio.dart';
+import 'package:audioplayers/audioplayers.dart';
 
 import './config.dart';
 import './models/radio_station.dart';
@@ -34,6 +37,7 @@ class _MyHomePageState extends State<MyHomePage> {
   PlayerState _playerState = PlayerState.STOPPED;
   StationList _externalStationsList = new StationList();
   List<RadioStation> _radioList = StationList.list;
+  AudioPlayer audioPlayer = AudioPlayer();
 
   _getMoreStations() {
     _externalStationsList.parseStreemaStationsInfo().then((stationsList) {
@@ -48,6 +52,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
+    AudioPlayer.logEnabled = true;
     _getMoreStations();
   }
 
@@ -63,10 +68,11 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
-  void _play() {
+  void _play() async {
     if (_playerState != PlayerState.PLAYING) {
       try {
-        FlutterRadio.play(url: this._radioList[_selectedIndex].url);
+        var _ = await audioPlayer.play(this._radioList[_selectedIndex].url);
+        _setNotification();
         setState(() => this._playerState = PlayerState.PLAYING);
       } catch (e) {
         print(e);
@@ -74,10 +80,18 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
+  void _setNotification() {
+    if (Platform.isIOS) {
+      audioPlayer.setNotification(
+        title: this._radioList[_selectedIndex].name,
+        artist: this._radioList[_selectedIndex].frequency.toString(),
+      );
+    }
+  }
+
   void _pause() {
     if (_playerState == PlayerState.PLAYING) {
       try {
-        FlutterRadio.pause(url: this._radioList[_selectedIndex].url);
         setState(() => this._playerState = PlayerState.PAUSED);
       } catch (e) {
         print(e);
@@ -85,11 +99,11 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
-  void _stop() {
+  void _stop() async {
     if (_playerState == PlayerState.PAUSED ||
         _playerState == PlayerState.PLAYING) {
       try {
-        FlutterRadio.stop();
+        await audioPlayer.stop();
         setState(() => this._playerState = PlayerState.STOPPED);
       } catch (e) {
         print(e);
@@ -138,7 +152,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   void dispose() {
-    FlutterRadio.stop();
+//    FlutterRadio.stop();
     super.dispose();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,11 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-//import 'package:flutter_radio/flutter_radio.dart';
-import 'package:audioplayers/audioplayers.dart';
 
-import './config.dart';
 import './models/radio_station.dart';
 import './models/station_list.dart';
-import './playerState.dart';
 import './widgets/bottom_navigation.dart';
 import './widgets/player.dart';
 import './widgets/radio_card.dart';
+import 'utils/config.dart';
 
 void main() => runApp(MyApp());
 
@@ -34,10 +29,8 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   int _selectedIndex = 0;
   bool _listLayoutState = false;
-  PlayerState _playerState = PlayerState.STOPPED;
   StationList _externalStationsList = new StationList();
   List<RadioStation> _radioList = StationList.list;
-  AudioPlayer audioPlayer = AudioPlayer();
 
   _getMoreStations() {
     _externalStationsList.parseStreemaStationsInfo().then((stationsList) {
@@ -52,62 +45,16 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    AudioPlayer.logEnabled = true;
     _getMoreStations();
   }
 
   void _selectStation(int index) async {
     if (this._selectedIndex != index) {
-      _stop();
       setState(() {
         this._radioList[_selectedIndex].selected = false;
         this._selectedIndex = index;
         this._radioList[this._selectedIndex].selected = true;
       });
-      _play();
-    }
-  }
-
-  void _play() async {
-    if (_playerState != PlayerState.PLAYING) {
-      try {
-        var _ = await audioPlayer.play(this._radioList[_selectedIndex].url);
-        _setNotification();
-        setState(() => this._playerState = PlayerState.PLAYING);
-      } catch (e) {
-        print(e);
-      }
-    }
-  }
-
-  void _setNotification() {
-    if (Platform.isIOS) {
-      audioPlayer.setNotification(
-        title: this._radioList[_selectedIndex].name,
-        artist: this._radioList[_selectedIndex].frequency.toString(),
-      );
-    }
-  }
-
-  void _pause() {
-    if (_playerState == PlayerState.PLAYING) {
-      try {
-        setState(() => this._playerState = PlayerState.PAUSED);
-      } catch (e) {
-        print(e);
-      }
-    }
-  }
-
-  void _stop() async {
-    if (_playerState == PlayerState.PAUSED ||
-        _playerState == PlayerState.PLAYING) {
-      try {
-        await audioPlayer.stop();
-        setState(() => this._playerState = PlayerState.STOPPED);
-      } catch (e) {
-        print(e);
-      }
     }
   }
 
@@ -148,12 +95,6 @@ class _MyHomePageState extends State<MyHomePage> {
         );
       }).toList(),
     );
-  }
-
-  @override
-  void dispose() {
-//    FlutterRadio.stop();
-    super.dispose();
   }
 
   @override
@@ -201,10 +142,7 @@ class _MyHomePageState extends State<MyHomePage> {
               title: _radioList[_selectedIndex].name,
               freq: _radioList[_selectedIndex].frequency,
               url: _radioList[_selectedIndex].url,
-              play: this._play,
-              pause: this._pause,
-              stop: this._stop,
-              state: this._playerState,
+              index: _selectedIndex,
             ),
             BottomNavigation(),
           ],

--- a/lib/models/station_list.dart
+++ b/lib/models/station_list.dart
@@ -51,9 +51,9 @@ class StationList {
     var client = http.Client();
     try {
       for (int i = 0; i < list.length; i++) {
-        String URL = "${streemaBaseURL}${list[i]["streema-data-url"]}";
+        String url = "$streemaBaseURL${list[i]["streema-data-url"]}";
         String title = list[i]["title"];
-        String response = await client.read(URL);
+        String response = await client.read(url);
         Document parsedRes = parse(response);
         var streamURL = parsedRes.querySelector("audio");
         if (streamURL != null &&
@@ -133,11 +133,6 @@ class StationList {
       "Radio Masr El-Gdida",
       0.0,
       "http://streaming.radio.co:80/scc13a6b96/listen",
-    ),
-    RadioStation(
-      "راديو مصر",
-      88.7,
-      "http://live.radiomasr.net:8060/RADIOMASR",
     ),
     RadioStation(
       "راديو مصر",

--- a/lib/playerState.dart
+++ b/lib/playerState.dart
@@ -2,4 +2,5 @@ enum PlayerState {
   STOPPED,
   PLAYING,
   PAUSED,
+  LOADING,
 }

--- a/lib/screens/favorites.dart
+++ b/lib/screens/favorites.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../config.dart';
+import '../utils/config.dart';
 
 class FavoritesScreen extends StatelessWidget {
   @override

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../config.dart';
+import '../utils/config.dart';
 
 class SettingsScreen extends StatelessWidget {
   @override

--- a/lib/utils/config.dart
+++ b/lib/utils/config.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-import './screens/favorites.dart';
+import '../screens/favorites.dart';
 
 class Config {
   static const String title = "Egypt Radio";

--- a/lib/widgets/player.dart
+++ b/lib/widgets/player.dart
@@ -1,7 +1,4 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_radio/flutter_radio.dart';
 
 import '../playerState.dart';
 
@@ -30,22 +27,6 @@ class Player extends StatefulWidget {
 }
 
 class _PlayerState extends State<Player> {
-  @override
-  void initState() {
-    super.initState();
-    _audioStart();
-  }
-
-  Future<void> _audioStart() async {
-    await FlutterRadio.audioStart();
-  }
-
-  @override
-  void dispose() {
-    FlutterRadio.stop();
-    super.dispose();
-  }
-
   Icon _playBtnIcon() {
     if (widget.state == PlayerState.PLAYING) {
       return Icon(
@@ -82,15 +63,10 @@ class _PlayerState extends State<Player> {
           colors: [
             Color(0xFF263241),
             Color(0xFF413f6A),
-//            Color(0xFF7D3F80),
-//            Color(0xFFC02F75),
-//            Color(0xFFF1304C),
           ],
         ),
       ),
       child: Row(
-//        mainAxisSize: MainAxisSize.min,
-//        crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           Expanded(
             child: Padding(
@@ -108,7 +84,6 @@ class _PlayerState extends State<Player> {
               size: 30,
             ),
             padding: EdgeInsets.only(top: 5, right: 20.0),
-//            alignment: Alignment.bottomCenter,
             onPressed: () => widget.pause(),
           ),
           IconButton(
@@ -116,17 +91,6 @@ class _PlayerState extends State<Player> {
             onPressed: _playPause,
             padding: EdgeInsets.only(right: 0.0),
           ),
-//          Expanded(
-//            flex: 1,
-//            child: Row(
-//              crossAxisAlignment: CrossAxisAlignment.center,
-//              mainAxisAlignment: MainAxisAlignment.center,
-//              mainAxisSize: MainAxisSize.max,
-//              children: <Widget>[
-//
-//              ],
-//            ),
-//          ),
         ],
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -22,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  audioplayers:
+    dependency: "direct main"
+    description:
+      name: audioplayers
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.7"
   boolean_selector:
     dependency: transitive
     description:
@@ -76,13 +83,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_radio:
-    dependency: "direct main"
-    description:
-      name: flutter_radio
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.7"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -108,7 +108,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0+3"
+    version: "0.12.0+4"
   http_parser:
     dependency: transitive
     description:
@@ -233,6 +233,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -83,8 +83,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_media_notification:
+    dependency: "direct main"
+    description:
+      name: flutter_media_notification
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.6"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -145,7 +157,7 @@ packages:
     source: hosted
     version: "1.6.4"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
@@ -179,6 +191,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.6"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+3"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2+2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -255,5 +295,5 @@ packages:
     source: hosted
     version: "3.5.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
-  flutter: ">=1.10.0 <2.0.0"
+  dart: ">=2.5.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,8 +23,10 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-#  flutter_radio: ^0.1.7
   audioplayers: ^0.13.7
+  shared_preferences: ^0.5.6
+  flutter_media_notification: ^1.2.6
+  path_provider: ^1.5.1
   google_fonts: ^0.2.0
   http: ^0.12.0+3
   html: ^0.14.0+3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  flutter_radio: ^0.1.7
+#  flutter_radio: ^0.1.7
+  audioplayers: ^0.13.7
   google_fonts: ^0.2.0
   http: ^0.12.0+3
   html: ^0.14.0+3


### PR DESCRIPTION
In this PR, I changed the audio player plugin used to play remote URLs to use [audioplayers](https://pub.dev/packages/audioplayers) instead of [flutter_radio](https://pub.dev/packages/flutter_radio) since I noticed that using flutter_radio caused build failures on iOS 13+ due to some deprecated code I believe. I generally noticed that audioplayers was much better in the fact that it provided ability to subscribe to state changes, logging, etc. It felt like a solid foundation to use for the future of this application. Although I am still have some minor issues with it such as being able to detect a loading state while the stream started *actually* playing, is not currently something that's available. Another thing is the media notification not being currently available on Android. I believe there are some open PRs open which should add this so I am using [flutter_media_notification](https://pub.dev/packages/flutter_media_notification) instead which ironically only supports Android and not iOS yet :)

Another major things that was done in this PR, is moving all of the state management and functions for the player widget from the main homepage widget to the player widget itself. This caused setState() to behave a bit odd and I am still running into some edge cases but it feels like this was the right step to have all the player controls contained within itself rather than on the homepage widget.